### PR TITLE
Bugfix: hide overlay after exiting out of camera

### DIFF
--- a/client/cl_main.lua
+++ b/client/cl_main.lua
@@ -201,6 +201,7 @@ function CameraLoop()
         DestroyCam(cam, false)
         SetNightvision(false)
         SetSeethrough(false)
+        SendNUIMessage({action = "hideOverlay"})
     end)
 end
 


### PR DESCRIPTION
When not taking a picture after opening the camera, but instead exiting out of the camera by pressing ESC or right-clicking, the overlay would stay active. This will close the overlay after the camera-loop ends.

The bug was also mentioned in #5 