### PR TITLE
Render full image in card without cropping

### DIFF
--- a/client/nui/main.css
+++ b/client/nui/main.css
@@ -14,7 +14,7 @@ body {
 .picture-container {
 	position: relative;
 	width: 1000px;
-	height: 1000px;
+	height: 700px;
 	padding: 25px;
 	border: 1px solid #999999;
 	border-radius: 2px;
@@ -25,13 +25,13 @@ body {
 
 .picture {
 	background-repeat: no-repeat;
-	background-size: cover;
+	background-size: contain;
 	width: 100%;
 	height: 90%;
 }
 
 .info {
-	margin-top: 3em;
+	margin-top: 1em;
 	text-align: center;
 	user-select: none;
 	font-family: 'Encode Sans SC', sans-serif;


### PR DESCRIPTION
This PR modifies the rendered polaroid to show the full image instead of cropping.

As a result, the image and polaroid are a bit more rectangular than square now, which could be seen as a downside (if we dont want to go this route, let me know and we can abandon this PR).

Thought behind change. As a user, if I take a picture and see that the camera is using the full width of my screen, I would expect when I open the photo that I see everything that was within frame when I took the shot. If the photo is cropped, its not clear which parts will be cropped out, which could make it more difficult to take the perfect picture. 

Using the same photo here is the before/after
BEFORE:
![image](https://user-images.githubusercontent.com/18689469/232335335-ee43e21c-d3d4-4e2f-ac79-8b5dcebab909.png)

AFTER
![image](https://user-images.githubusercontent.com/18689469/232335345-82e5cd56-e39d-4032-a68a-3b0a81980ed3.png)